### PR TITLE
Disable autocmds when modifying the buffer

### DIFF
--- a/plugin/jumpmotion.vim
+++ b/plugin/jumpmotion.vim
@@ -248,7 +248,7 @@ function JumpMotion(...) abort range
         endfor
 
         try
-          keepjumps execute 'normal! ' . edit
+          noautocmd keepjumps execute 'normal! ' edit
 
           keepjumps call winrestview(view)
           let &l:modified = oldmod
@@ -259,7 +259,7 @@ function JumpMotion(...) abort range
           unlet targets
           return
         finally
-          silent undo
+          noautocmd silent undo
         endtry
 
       catch
@@ -302,7 +302,7 @@ function JumpMotion(...) abort range
     elseif &undolevels ==# 1
       " Clear all history.
       setlocal undolevels=-1
-      call setline(1, getline(1))
+      noautocmd call setline(1, getline(1))
     endif
 
     keepjumps call winrestview(view)


### PR DESCRIPTION
This will avoid triggering heavy behavior of other plugins that may
listen on buffer changes, like coc.nvim and other plugins that
automatically lint the code.