### PR TITLE
Add g:jumpmotion_do_mapping option

### DIFF
--- a/plugin/jumpmotion.vim
+++ b/plugin/jumpmotion.vim
@@ -8,7 +8,7 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-if get('g:jumpmotion_do_mappings', 1) == 1 && !hasmapto('<Plug>(JumpMotion)')
+if get(g:, 'jumpmotion_do_mappings', 1) == 1 && !hasmapto('<Plug>(JumpMotion)')
   for s:lhs in ['<Space>', 's', '<Leader><Leader>', '<Leader><Space>', '<Leader>s']
     if empty(maparg(s:lhs))
       execute 'map <unique>' s:lhs '<Plug>(JumpMotion)'

--- a/plugin/jumpmotion.vim
+++ b/plugin/jumpmotion.vim
@@ -8,7 +8,7 @@ endif
 let s:save_cpo = &cpo
 set cpo&vim
 
-if !hasmapto('<Plug>(JumpMotion)')
+if get('g:jumpmotion_do_mappings', 1) == 1 && !hasmapto('<Plug>(JumpMotion)')
   for s:lhs in ['<Space>', 's', '<Leader><Leader>', '<Leader><Space>', '<Leader>s']
     if empty(maparg(s:lhs))
       execute 'map <unique>' s:lhs '<Plug>(JumpMotion)'


### PR DESCRIPTION
Allows the user to set `let g:jumpmotion_do_mapping = 0` to unconditionally disable the `<Plug>(JumpMotion)` mapping.

I am using this because I didn't like any of the default mappings and wanted more control. I think for the most part users appreciate having options like this.